### PR TITLE
IReqPayLnAddress fix

### DIFF
--- a/src/lib/HttpServer.ts
+++ b/src/lib/HttpServer.ts
@@ -24,6 +24,7 @@ import IRespLnurlPay from "../types/IRespLnurlPay";
 import IRespLnurlPayRequest from "../types/IRespLnurlPayRequest";
 import IReqUpdateLnurlPay from "../types/IReqUpdateLnurlPay";
 import IRespPayLnAddress from "../types/IRespPayLnAddress";
+import { IReqPayLnAddress } from "../types/IReqPayLnAddress";
 
 class HttpServer {
   // Create a new express application instance

--- a/src/lib/LnurlPay.ts
+++ b/src/lib/LnurlPay.ts
@@ -23,6 +23,7 @@ import { LnAddress } from "./LnAddress";
 import IRespPayLnAddress from "../types/IRespPayLnAddress";
 import IRespLnServicePayRequest from "../types/IRespLnServicePayRequest";
 import IRespLnurlPayRequest from "../types/IRespLnurlPayRequest";
+import { IReqPayLnAddress } from "../types/IReqPayLnAddress";
 
 class LnurlPay {
   private _lnurlConfig: LnurlConfig;
@@ -54,8 +55,8 @@ class LnurlPay {
       this._lnurlConfig.LN_SERVICE_DOMAIN +
       ((this._lnurlConfig.LN_SERVICE_SCHEME.toLowerCase() === "https" &&
         this._lnurlConfig.LN_SERVICE_PORT === 443) ||
-        (this._lnurlConfig.LN_SERVICE_SCHEME.toLowerCase() === "http" &&
-          this._lnurlConfig.LN_SERVICE_PORT === 80)
+      (this._lnurlConfig.LN_SERVICE_SCHEME.toLowerCase() === "http" &&
+        this._lnurlConfig.LN_SERVICE_PORT === 80)
         ? ""
         : ":" + this._lnurlConfig.LN_SERVICE_PORT) +
       this._lnurlConfig.LN_SERVICE_CTX +
@@ -731,6 +732,7 @@ class LnurlPay {
     if (bolt11) {
       const lnPayParams = {
         bolt11,
+        // eslint-disable-next-line @typescript-eslint/camelcase
         expected_msatoshi: req.amountMsat,
       };
 

--- a/src/types/IReqPayLnAddress.ts
+++ b/src/types/IReqPayLnAddress.ts
@@ -1,4 +1,4 @@
-interface IReqPayLnAddress {
+export interface IReqPayLnAddress {
   address: string;
   amountMsat: number;
 }


### PR DESCRIPTION
Fix for compile errors:

```
src/lib/HttpServer.ts(157,28): error TS2552: Cannot find name 'IReqPayLnAddress'. Did you mean 'IRespPayLnAddress'?
```